### PR TITLE
Padding fix on toolbar 

### DIFF
--- a/styles/headerbar.less
+++ b/styles/headerbar.less
@@ -14,6 +14,9 @@ div:not(.layout-mode-popout){
         padding-top: 5px;
       }
     }
+    div.item-container{
+      padding-right: 2em;
+    }
   }  
 }
 


### PR DESCRIPTION
Increased padding on toolbar item container to fix overlap with search input when activity badge was 3 digits.

![screen shot 2016-07-14 at 10 10 59 am](https://cloud.githubusercontent.com/assets/18057119/16842592/fe605532-49ab-11e6-9526-9baba07ae979.png)

<img width="73" alt="screen shot 2016-07-14 at 10 15 37 am" src="https://cloud.githubusercontent.com/assets/18057119/16842585/f8c365c4-49ab-11e6-9bcc-8e5b621c705e.png">
